### PR TITLE
Cio Firebase abstraction out of the main SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,137 @@
+.DS_Store
+test-report.*
+*.xcresult/
+gc_keys.json
+app_store_connect_creds.json
+Package.resolved
+
+# binny - ignore the binny binary and tools that binny downloads. 
+tools/
+binny 
+
+#############################################################################
+# Below from: https://github.com/github/gitignore/blob/master/Swift.gitignore
+#############################################################################
+
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+.DS_Store
+.github/.DS_Store
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+#
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+.swiftpm
+
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# Pods/
+#
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build/
+
+# Accio dependency management
+Dependencies/
+.accio/
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+#
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/
+Env.swift
+
+# FCM-specific additions
+# Firebase configuration files (if any)
+GoogleService-Info.plist
+firebase_options.dart
+
+# Environment-specific files
+.env
+.env.local
+.env.development
+.env.production
+
+# IDE files
+.vscode/
+.idea/
+
+# Temporary files
+*.tmp
+*.temp
+*~
+
+# Logs
+*.log
+logs/
+
+# Coverage reports
+coverage/
+*.coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## [1.0.0](https://github.com/customerio/customerio-ios-fcm/compare/initial...1.0.0) (2024-01-XX)
+
+### Features
+
+* Initial release of Customer.io Firebase Wrapper SDK

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# The catch-all default code owners for this repository
+*   @customerio/squad-mobile

--- a/CioFirebaseWrapper.podspec
+++ b/CioFirebaseWrapper.podspec
@@ -24,5 +24,5 @@ Pod::Spec.new do |spec|
   spec.dependency "CustomerIOMessagingPushFCM", ">= 3.13.0"
   
   # Add Firebase dependency - major version 12 up to next major version
-  spec.dependency "FirebaseMessaging", "~> 12.0"
+  spec.dependency "FirebaseMessaging", ">= 8.7.0", "< 13.0.0"
 end

--- a/CioFirebaseWrapper.podspec
+++ b/CioFirebaseWrapper.podspec
@@ -1,0 +1,28 @@
+Pod::Spec.new do |spec|
+  spec.name         = "CioFirebaseWrapper"
+  spec.version      = "1.0.0"
+  spec.summary      = "Customer.io Firebase Wrapper SDK for iOS."
+  spec.homepage     = "https://github.com/customerio/customerio-ios-fcm"
+  spec.documentation_url = 'https://customer.io/docs/sdk/ios/'
+  spec.changelog    = "https://github.com/customerio/customerio-ios-fcm/blob/#{spec.version.to_s}/CHANGELOG.md"
+  spec.license      = { :type => "MIT", :file => "LICENSE" }
+  spec.author       = { "CustomerIO Team" => "win@customer.io" }
+  spec.source       = { :git => 'https://github.com/customerio/customerio-ios-fcm.git', :tag => spec.version.to_s }
+
+  spec.swift_version = '5.5'
+  spec.cocoapods_version = '>= 1.11.0'
+
+  spec.platform = :ios
+  spec.ios.deployment_target = "15.0"
+
+  path_to_source_for_module = "Sources"
+  spec.source_files = "#{path_to_source_for_module}/**/*{.swift}"
+  
+  spec.module_name = "CioFirebaseWrapper"
+  
+  # Add main SDK dependency
+  spec.dependency "CustomerIOMessagingPushFCM", ">= 3.13.0"
+  
+  # Add Firebase dependency - major version 12 up to next major version
+  spec.dependency "FirebaseMessaging", "~> 12.0"
+end

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [
          .package(url: "https://github.com/customerio/customerio-ios.git", branch: "test-wrapper"),
-         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", .upToNextMajor(from: "12.0.0"))
+         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", "8.7.0"..<"13.0.0")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,38 @@
+// swift-tools-version:5.5
+
+import PackageDescription
+
+let package = Package(
+    name: "CioFirebaseWrapper",
+    platforms: [
+        .iOS(.v15)
+    ],
+    products: [
+        .library(
+            name: "CioFirebaseWrapper",
+            targets: ["CioFirebaseWrapper"]
+        )
+    ],
+    dependencies: [
+         .package(url: "https://github.com/customerio/customerio-ios.git", branch: "test-wrapper"),
+         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", .upToNextMajor(from: "12.0.0"))
+    ],
+    targets: [
+        .target(
+            name: "CioFirebaseWrapper",
+            dependencies: [
+                .product(name: "MessagingPushFCM", package: "customerio-ios"),
+                .product(name: "FirebaseMessaging", package: "firebase-ios-sdk")
+            ],
+            path: "Sources"
+        ),
+        .testTarget(
+            name: "CioFirebaseWrapperTests",
+            dependencies: [
+                "CioFirebaseWrapper",
+                .product(name: "MessagingPushFCM", package: "customerio-ios")
+            ],
+            path: "Tests"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# customerio-ios-fcm
+# Customer.io Firebase Wrapper SDK for iOS
+
+Customer.io SDK to abstract iOS Firebase Cloud Messaging (FCM) integration from the main SDK.
+
+## Requirements
+
+- iOS 15.0+
+- Xcode 14.0+
+- Swift 5.5+
+
+## Installation
+
+### Swift Package Manager
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/customerio/customerio-ios-fcm.git", from: "1.0.0")
+]
+```
+
+### CocoaPods
+
+```ruby
+pod 'CioFirebaseWrapper', '~> 1.0'
+```
+
+## License
+
+MIT License. See LICENSE file for details.
+    

--- a/Sources/CioFirebaseWrapper.swift
+++ b/Sources/CioFirebaseWrapper.swift
@@ -1,0 +1,36 @@
+import CioMessagingPushFCM
+import FirebaseMessaging
+
+internal class FirebaseImpl: FirebaseService {
+    private let firebaseAdapter = FirebaseDelegateAdapter(cioFCMMessagingDelegate: nil)
+    
+    public var apnsToken: Data? {
+        get { return Messaging.messaging().apnsToken }
+        set { Messaging.messaging().apnsToken = newValue }
+    }
+
+    public var delegate: FirebaseServiceDelegate? {
+        get { return firebaseAdapter.cioFCMMessagingDelegate }
+        set {
+            firebaseAdapter.cioFCMMessagingDelegate = newValue
+            Messaging.messaging().delegate = firebaseAdapter
+        }
+    }
+
+    public func fetchToken(completion: @escaping (String?, Error?) -> Void) {
+        Messaging.messaging().token(completion: completion)
+    }
+}
+
+// Firebase delegate adapter to bridge between CioFCMMessagingDelegate and MessagingDelegate
+internal class FirebaseDelegateAdapter: NSObject, MessagingDelegate {
+    weak var cioFCMMessagingDelegate: FirebaseServiceDelegate?
+    
+    public init(cioFCMMessagingDelegate: FirebaseServiceDelegate?) {
+        self.cioFCMMessagingDelegate = cioFCMMessagingDelegate
+    }
+    
+    public func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        cioFCMMessagingDelegate?.didReceiveRegistrationToken(fcmToken)
+    }
+}

--- a/Sources/MessagingPushFCM+Init.swift
+++ b/Sources/MessagingPushFCM+Init.swift
@@ -1,0 +1,19 @@
+import CioMessagingPush
+import CioMessagingPushFCM
+
+import Foundation
+
+extension MessagingPushFCM {
+    /**
+     Initialize and configure `MessagingPushFCM`.
+     Call this function in your app if you want to initialize and configure the module to
+     auto-fetch device token and auto-register device with Customer.io.
+     */
+    @discardableResult
+    @available(iOSApplicationExtension, unavailable)
+    public static func initialize(
+        withConfig config: MessagingPushConfigOptions = MessagingPushConfigBuilder().build()
+    ) -> MessagingPushInstance {
+        return internalSetup(withConfig: config, firebaseService: FirebaseImpl())
+    }
+}

--- a/Tests/APITest.swift
+++ b/Tests/APITest.swift
@@ -1,0 +1,15 @@
+import Foundation
+import XCTest
+// Do not use `@testable` so we can test functions are made public and not `internal`.
+import CioFirebaseWrapper
+import CioMessagingPushFCM
+
+class CioFirebaseWrapperAPITest: XCTestCase {
+    
+    func test_allPublicFunctions() throws {
+        // Test that MessagingPushFCM.initialize() is accessible through the CioFirebaseWrapper extension
+        // This is the main public API that consumers will use
+        let _ = MessagingPushFCM.initialize()
+        let _ = MessagingPushFCM.initialize(withConfig: MessagingPushConfigBuilder().build())
+    }
+}

--- a/Tests/FirebaseDelegateAdapterTests.swift
+++ b/Tests/FirebaseDelegateAdapterTests.swift
@@ -1,0 +1,152 @@
+import XCTest
+import FirebaseMessaging
+@testable import CioFirebaseWrapper
+import CioMessagingPushFCM
+
+class FirebaseDelegateAdapterTests: XCTestCase {
+    
+    var adapter: FirebaseDelegateAdapter!
+    var mockDelegate: MockFirebaseServiceDelegate!
+    
+    override func setUp() {
+        super.setUp()
+        mockDelegate = MockFirebaseServiceDelegate()
+        adapter = FirebaseDelegateAdapter(cioFCMMessagingDelegate: mockDelegate)
+    }
+    
+    override func tearDown() {
+        adapter = nil
+        mockDelegate = nil
+        super.tearDown()
+    }
+    
+    // MARK: - Initialization Tests
+    
+    func testInitializationWithDelegate() {
+        // Given
+        let delegate = MockFirebaseServiceDelegate()
+        
+        // When
+        let adapter = FirebaseDelegateAdapter(cioFCMMessagingDelegate: delegate)
+        
+        // Then
+        XCTAssertNotNil(adapter)
+        XCTAssertTrue(adapter.cioFCMMessagingDelegate === delegate)
+    }
+    
+    func testInitializationWithNilDelegate() {
+        // When
+        let adapter = FirebaseDelegateAdapter(cioFCMMessagingDelegate: nil)
+        
+        // Then
+        XCTAssertNotNil(adapter)
+        XCTAssertNil(adapter.cioFCMMessagingDelegate)
+    }
+    
+    // MARK: - Delegate Forwarding Tests
+    
+    func testMessagingDelegateMethodForwardsToMockDelegate() {
+        // Given
+        let expectedToken = "test_fcm_token_12345"
+        let mockMessaging = Messaging.messaging()
+        
+        // When
+        adapter.messaging(mockMessaging, didReceiveRegistrationToken: expectedToken)
+        
+        // Then
+        XCTAssertEqual(mockDelegate.receivedToken, expectedToken)
+        XCTAssertEqual(mockDelegate.tokenCallCount, 1)
+    }
+    
+    func testMessagingDelegateMethodWithNilToken() {
+        // Given
+        let mockMessaging = Messaging.messaging()
+        
+        // When
+        adapter.messaging(mockMessaging, didReceiveRegistrationToken: nil)
+        
+        // Then
+        XCTAssertNil(mockDelegate.receivedToken)
+        XCTAssertEqual(mockDelegate.tokenCallCount, 1)
+    }
+    
+    func testMessagingDelegateMethodWithEmptyToken() {
+        // Given
+        let emptyToken = ""
+        let mockMessaging = Messaging.messaging()
+        
+        // When
+        adapter.messaging(mockMessaging, didReceiveRegistrationToken: emptyToken)
+        
+        // Then
+        XCTAssertEqual(mockDelegate.receivedToken, emptyToken)
+        XCTAssertEqual(mockDelegate.tokenCallCount, 1)
+    }
+    
+    func testMultipleTokenUpdates() {
+        // Given
+        let token1 = "token_1"
+        let token2 = "token_2"
+        let token3 = "token_3"
+        let mockMessaging = Messaging.messaging()
+        
+        // When
+        adapter.messaging(mockMessaging, didReceiveRegistrationToken: token1)
+        adapter.messaging(mockMessaging, didReceiveRegistrationToken: token2)
+        adapter.messaging(mockMessaging, didReceiveRegistrationToken: token3)
+        
+        // Then
+        XCTAssertEqual(mockDelegate.receivedToken, token3)
+        XCTAssertEqual(mockDelegate.tokenCallCount, 3)
+    }
+    
+    // MARK: - Delegate Management Tests
+    
+    func testDelegateCanBeChanged() {
+        // Given
+        let newDelegate = MockFirebaseServiceDelegate()
+        let token = "test_token"
+        let mockMessaging = Messaging.messaging()
+        
+        // When
+        adapter.cioFCMMessagingDelegate = newDelegate
+        adapter.messaging(mockMessaging, didReceiveRegistrationToken: token)
+        
+        // Then
+        XCTAssertTrue(adapter.cioFCMMessagingDelegate === newDelegate)
+        XCTAssertEqual(newDelegate.receivedToken, token)
+        XCTAssertEqual(newDelegate.tokenCallCount, 1)
+        XCTAssertEqual(mockDelegate.tokenCallCount, 0)
+    }
+    
+    func testDelegateCanBeSetToNil() {
+        // Given
+        let token = "test_token"
+        let mockMessaging = Messaging.messaging()
+        
+        // When
+        adapter.cioFCMMessagingDelegate = nil
+        adapter.messaging(mockMessaging, didReceiveRegistrationToken: token)
+        
+        // Then
+        XCTAssertNil(adapter.cioFCMMessagingDelegate)
+        XCTAssertEqual(mockDelegate.tokenCallCount, 0)
+    }
+}
+
+// MARK: - Mock FirebaseServiceDelegate
+
+class MockFirebaseServiceDelegate: FirebaseServiceDelegate {
+    var receivedToken: String?
+    var tokenCallCount = 0
+    
+    func didReceiveRegistrationToken(_ token: String?) {
+        receivedToken = token
+        tokenCallCount += 1
+    }
+    
+    func reset() {
+        receivedToken = nil
+        tokenCallCount = 0
+    }
+}

--- a/Tests/FirebaseMessagingTests.swift
+++ b/Tests/FirebaseMessagingTests.swift
@@ -1,0 +1,277 @@
+import XCTest
+import FirebaseMessaging
+@testable import CioFirebaseWrapper
+import CioMessagingPushFCM
+
+class FirebaseMessagingTests: XCTestCase {
+    
+    var mockMessagingDelegate: MockMessagingDelegate!
+    var mockFirebaseServiceDelegate: MockFirebaseServiceDelegate!
+    var mockFirebaseMessaging: MockFirebaseMessaging!
+    var adapter: FirebaseDelegateAdapter!
+    
+    override func setUp() {
+        super.setUp()
+        
+        // Set up Firebase messaging swizzling for testing
+        Messaging.swizzleMessaging()
+        
+        // Initialize mocks
+        mockMessagingDelegate = MockMessagingDelegate()
+        mockFirebaseServiceDelegate = MockFirebaseServiceDelegate()
+        mockFirebaseMessaging = MockFirebaseMessaging()
+        adapter = FirebaseDelegateAdapter(cioFCMMessagingDelegate: mockFirebaseServiceDelegate)
+    }
+    
+    override func tearDown() {
+        // Clean up swizzling
+        Messaging.unswizzleMessaging()
+        
+        mockMessagingDelegate = nil
+        mockFirebaseServiceDelegate = nil
+        mockFirebaseMessaging = nil
+        adapter = nil
+        
+        super.tearDown()
+    }
+    
+    // MARK: - MockMessagingDelegate Tests
+    
+    func testMockMessagingDelegateInitialization() {
+        // Given & When
+        let delegate = MockMessagingDelegate()
+        
+        // Then
+        XCTAssertFalse(delegate.didReceiveRegistrationTokenCalled)
+        XCTAssertNil(delegate.fcmTokenReceived)
+    }
+    
+    func testMockMessagingDelegateReceivesToken() {
+        // Given
+        let expectedToken = TestData.validFCMToken
+        let mockMessaging = Messaging.messaging()
+        
+        // When
+        mockMessagingDelegate.messaging(mockMessaging, didReceiveRegistrationToken: expectedToken)
+        
+        // Then
+        XCTAssertTrue(mockMessagingDelegate.didReceiveRegistrationTokenCalled)
+        XCTAssertEqual(mockMessagingDelegate.fcmTokenReceived, expectedToken)
+    }
+    
+    func testMockMessagingDelegateReceivesNilToken() {
+        // Given
+        let mockMessaging = Messaging.messaging()
+        
+        // When
+        mockMessagingDelegate.messaging(mockMessaging, didReceiveRegistrationToken: nil)
+        
+        // Then
+        XCTAssertTrue(mockMessagingDelegate.didReceiveRegistrationTokenCalled)
+        XCTAssertNil(mockMessagingDelegate.fcmTokenReceived)
+    }
+    
+    func testMockMessagingDelegateReceivesEmptyToken() {
+        // Given
+        let emptyToken = TestData.invalidToken
+        let mockMessaging = Messaging.messaging()
+        
+        // When
+        mockMessagingDelegate.messaging(mockMessaging, didReceiveRegistrationToken: emptyToken)
+        
+        // Then
+        XCTAssertTrue(mockMessagingDelegate.didReceiveRegistrationTokenCalled)
+        XCTAssertEqual(mockMessagingDelegate.fcmTokenReceived, emptyToken)
+    }
+    
+    func testMockMessagingDelegateMultipleTokenUpdates() {
+        // Given
+        let token1 = "token_1"
+        let token2 = "token_2"
+        let token3 = "token_3"
+        let mockMessaging = Messaging.messaging()
+        
+        // When
+        mockMessagingDelegate.messaging(mockMessaging, didReceiveRegistrationToken: token1)
+        mockMessagingDelegate.messaging(mockMessaging, didReceiveRegistrationToken: token2)
+        mockMessagingDelegate.messaging(mockMessaging, didReceiveRegistrationToken: token3)
+        
+        // Then
+        XCTAssertTrue(mockMessagingDelegate.didReceiveRegistrationTokenCalled)
+        XCTAssertEqual(mockMessagingDelegate.fcmTokenReceived, token3)
+    }
+    
+    // MARK: - MockFirebaseMessaging Tests
+    
+    func testMockFirebaseMessagingInitialization() {
+        // Given & When
+        let mockMessaging = MockFirebaseMessaging()
+        
+        // Then
+        XCTAssertNil(mockMessaging.mockApnsToken)
+        XCTAssertNil(mockMessaging.mockDelegate)
+        XCTAssertNil(mockMessaging.tokenCompletion)
+        XCTAssertEqual(mockMessaging.tokenCallCount, 0)
+    }
+    
+    func testMockFirebaseMessagingSimulateTokenSuccess() {
+        // Given
+        let expectedToken = TestData.validFCMToken
+        var receivedToken: String?
+        var receivedError: Error?
+        
+        mockFirebaseMessaging.tokenCompletion = { token, error in
+            receivedToken = token
+            receivedError = error
+        }
+        
+        // When
+        mockFirebaseMessaging.simulateTokenSuccess(expectedToken)
+        
+        // Then
+        XCTAssertEqual(receivedToken, expectedToken)
+        XCTAssertNil(receivedError)
+    }
+    
+    func testMockFirebaseMessagingSimulateTokenError() {
+        // Given
+        let expectedError = TestError.tokenError
+        var receivedToken: String?
+        var receivedError: Error?
+        
+        mockFirebaseMessaging.tokenCompletion = { token, error in
+            receivedToken = token
+            receivedError = error
+        }
+        
+        // When
+        mockFirebaseMessaging.simulateTokenError(expectedError)
+        
+        // Then
+        XCTAssertNil(receivedToken)
+        XCTAssertEqual(receivedError as? TestError, expectedError)
+    }
+    
+    func testMockFirebaseMessagingSimulateRegistrationToken() {
+        // Given
+        let expectedToken = TestData.validFCMToken
+        mockFirebaseMessaging.mockDelegate = mockMessagingDelegate
+        
+        // When
+        mockFirebaseMessaging.simulateRegistrationToken(expectedToken)
+        
+        // Then
+        XCTAssertTrue(mockMessagingDelegate.didReceiveRegistrationTokenCalled)
+        XCTAssertEqual(mockMessagingDelegate.fcmTokenReceived, expectedToken)
+    }
+    
+    func testMockFirebaseMessagingSimulateRegistrationTokenWithNilDelegate() {
+        // Given
+        let expectedToken = TestData.validFCMToken
+        mockFirebaseMessaging.mockDelegate = nil
+        
+        // When
+        mockFirebaseMessaging.simulateRegistrationToken(expectedToken)
+        
+        // Then
+        // Should not crash and delegate should not be called
+        XCTAssertFalse(mockMessagingDelegate.didReceiveRegistrationTokenCalled)
+        XCTAssertNil(mockMessagingDelegate.fcmTokenReceived)
+    }
+    
+    // MARK: - FirebaseDelegateAdapter Integration Tests
+    
+    func testFirebaseDelegateAdapterWithMockFirebaseServiceDelegate() {
+        // Given
+        let expectedToken = TestData.validFCMToken
+        let mockMessaging = Messaging.messaging()
+        let mockFirebaseServiceDelegate = MockFirebaseServiceDelegate()
+        let adapter = FirebaseDelegateAdapter(cioFCMMessagingDelegate: mockFirebaseServiceDelegate)
+        
+        // When
+        adapter.messaging(mockMessaging, didReceiveRegistrationToken: expectedToken)
+        
+        // Then
+        XCTAssertEqual(mockFirebaseServiceDelegate.receivedToken, expectedToken)
+        XCTAssertEqual(mockFirebaseServiceDelegate.tokenCallCount, 1)
+    }
+    
+    func testFirebaseDelegateAdapterWithNilDelegate() {
+        // Given
+        let adapterWithNilDelegate = FirebaseDelegateAdapter(cioFCMMessagingDelegate: nil)
+        let expectedToken = TestData.validFCMToken
+        let mockMessaging = Messaging.messaging()
+        
+        // When
+        adapterWithNilDelegate.messaging(mockMessaging, didReceiveRegistrationToken: expectedToken)
+        
+        // Then
+        // Should not crash when delegate is nil
+        XCTAssertNil(adapterWithNilDelegate.cioFCMMessagingDelegate)
+    }
+    
+    func testFirebaseDelegateAdapterDelegateChange() {
+        // Given
+        let newDelegate = MockFirebaseServiceDelegate()
+        let expectedToken = TestData.validFCMToken
+        let mockMessaging = Messaging.messaging()
+        let mockFirebaseServiceDelegate = MockFirebaseServiceDelegate()
+        let adapter = FirebaseDelegateAdapter(cioFCMMessagingDelegate: mockFirebaseServiceDelegate)
+        
+        // When
+        adapter.cioFCMMessagingDelegate = newDelegate
+        adapter.messaging(mockMessaging, didReceiveRegistrationToken: expectedToken)
+        
+        // Then
+        XCTAssertEqual(newDelegate.receivedToken, expectedToken)
+        XCTAssertEqual(newDelegate.tokenCallCount, 1)
+        XCTAssertEqual(mockFirebaseServiceDelegate.tokenCallCount, 0)
+    }
+    
+    // MARK: - Error Handling Tests
+    
+    func testTestErrorEquality() {
+        // Given
+        let error1 = TestError.networkError
+        let error2 = TestError.networkError
+        let error3 = TestError.tokenError
+        
+        // Then
+        XCTAssertEqual(error1, error2)
+        XCTAssertNotEqual(error1, error3)
+    }
+    
+    func testTestDataConstants() {
+        // Then
+        XCTAssertNotNil(TestData.validApnsToken)
+        XCTAssertEqual(TestData.validFCMToken, "valid_fcm_token_12345")
+        XCTAssertEqual(TestData.invalidToken, "")
+    }
+    
+    // MARK: - Integration Tests with Real Firebase Messaging
+    
+    func testIntegrationWithRealFirebaseMessaging() {
+        // Given
+        let realMessaging = Messaging.messaging()
+        let expectedToken = TestData.validFCMToken
+        
+        // When
+        mockMessagingDelegate.messaging(realMessaging, didReceiveRegistrationToken: expectedToken)
+        
+        // Then
+        XCTAssertTrue(mockMessagingDelegate.didReceiveRegistrationTokenCalled)
+        XCTAssertEqual(mockMessagingDelegate.fcmTokenReceived, expectedToken)
+    }
+    
+    func testIntegrationWithRealFirebaseMessagingNilToken() {
+        // Given
+        let realMessaging = Messaging.messaging()
+        
+        // When
+        mockMessagingDelegate.messaging(realMessaging, didReceiveRegistrationToken: nil)
+        
+        // Then
+        XCTAssertTrue(mockMessagingDelegate.didReceiveRegistrationTokenCalled)
+        XCTAssertNil(mockMessagingDelegate.fcmTokenReceived)
+    }
+}

--- a/Tests/Mocks.swift
+++ b/Tests/Mocks.swift
@@ -1,0 +1,75 @@
+import Foundation
+import FirebaseMessaging
+@testable import CioFirebaseWrapper
+import CioMessagingPushFCM
+
+// MARK: - Mock FirebaseMessaging
+
+class MockFirebaseMessaging {
+    var mockApnsToken: Data?
+    var mockDelegate: MessagingDelegate?
+    var tokenCompletion: ((String?, Error?) -> Void)?
+    var tokenCallCount = 0
+    
+    // Helper methods for testing
+    func simulateTokenSuccess(_ token: String) {
+        tokenCompletion?(token, nil)
+    }
+    
+    func simulateTokenError(_ error: Error) {
+        tokenCompletion?(nil, error)
+    }
+    
+    func simulateRegistrationToken(_ token: String?) {
+        if let delegate = mockDelegate {
+            let messaging = Messaging.messaging()
+            delegate.messaging!(messaging, didReceiveRegistrationToken: token)
+        }
+    }
+}
+
+// MARK: - Test Error
+
+enum TestError: Error, Equatable {
+    case networkError
+    case tokenError
+    case configurationError
+}
+
+// MARK: - Test Data
+
+struct TestData {
+    static let validApnsToken = Data([0x01, 0x02, 0x03, 0x04, 0x05])
+    static let validFCMToken = "valid_fcm_token_12345"
+    static let invalidToken = ""
+}
+
+// MARK: - Firebase Messaging Mocks (moved from customerio-ios)
+
+class MockMessagingDelegate: NSObject, MessagingDelegate {
+    var didReceiveRegistrationTokenCalled = false
+    var fcmTokenReceived: String?
+
+    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        didReceiveRegistrationTokenCalled = true
+        fcmTokenReceived = fcmToken
+    }
+}
+
+public extension Messaging {
+    static func swizzleMessaging() {
+        let originalMethod = class_getClassMethod(Messaging.self, #selector(Messaging.messaging))!
+        let swizzledMethod = class_getClassMethod(Messaging.self, #selector(Messaging.messagingMock))!
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+    }
+
+    static func unswizzleMessaging() {
+        swizzleMessaging() // Calling again will swap back
+    }
+
+    @objc class func messagingMock() -> Messaging {
+        let dummyObject = NSObject()
+        let messaging = unsafeBitCast(dummyObject, to: Messaging.self)
+        return messaging
+    }
+}


### PR DESCRIPTION
Closes: [MBL-1405](https://linear.app/customerio/issue/MBL-1405/move-ios-fcm-product-code-to-new-repo)

## Overview
This PR breaks the tight coupling between the Customer.io iOS SDK and Firebase Messaging by abstracting Firebase functionality into a separate wrapper package. This allows the main SDK to support lower iOS deployment targets while Firebase-specific features remain available through an optional package.

## Primary Goal
Remove Firebase's minimum deployment target constraint from the main Customer.io iOS SDK by:
- Abstracting Firebase Messaging behind protocol-based interfaces
- Moving Firebase-specific code to a separate customerio-ios-fcm package

## Package Separation
- Main SDK (customerio-ios): Contains abstracted protocols, no Firebase imports
- FCM Wrapper (customerio-ios-fcm): Contains Firebase implementation and public API

## Migration
No breaking code changes for consumers! The public API remains identical:
```swift
MessagingPushFCM.initialize()
MessagingPushFCM.initialize(withConfig: config)
```

## Testing
- Tested this with our sample app using this branch as dependency
- Adde unit tests for the implementation and API