### PR TITLE
ci: require Xcode 26 instead of capping firebase-ios-sdk

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -146,7 +146,7 @@ jobs:
     if: ${{ needs.deploy-git-tag.outputs.new_release_published == 'true' || github.event_name == 'workflow_dispatch' }}
     env:
       COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Checkout git tag that got created in previous step
         uses: actions/checkout@v4
@@ -169,7 +169,7 @@ jobs:
             echo "version=${{ inputs.existing-git-tag }}" >> $GITHUB_OUTPUT
           fi
 
-      - uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@main
+      - uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@MacOS-15+iOS-26
 
       - name: Install cocoapods
         run: gem install cocoapods

--- a/Package.swift
+++ b/Package.swift
@@ -15,12 +15,7 @@ let package = Package(
     ],
     dependencies: [
          .package(url: "https://github.com/customerio/customerio-ios.git", from: "4.0.0"),
-         // Upper bound capped below 12.13.0: that release added a trailing comma in a
-         // function-call argument list to its Package.swift (Swift 6.1 syntax), which
-         // the Xcode 16.2 toolchain used by CI rejects with
-         //   /Package.swift:199:5: error: unexpected ',' separator
-         // Lift the cap once CI is on Xcode 16.3+ (Swift 6.1).
-         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", "8.7.0"..<"12.13.0")
+         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", "8.7.0"..<"13.0.0")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,12 @@ let package = Package(
     ],
     dependencies: [
          .package(url: "https://github.com/customerio/customerio-ios.git", from: "4.0.0"),
-         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", "8.7.0"..<"13.0.0")
+         // Upper bound capped below 12.13.0: that release added a trailing comma in a
+         // function-call argument list to its Package.swift (Swift 6.1 syntax), which
+         // the Xcode 16.2 toolchain used by CI rejects with
+         //   /Package.swift:199:5: error: unexpected ',' separator
+         // Lift the cap once CI is on Xcode 16.3+ (Swift 6.1).
+         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", "8.7.0"..<"12.13.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Overview

The `Tests` workflow had been red on every PR/`main` run since 2026-05-05 because every fresh SPM resolution lands on `firebase-ios-sdk` **12.13.0**, whose `Package.swift` uses a trailing comma in a function-call argument list (Swift 6.1 syntax) that the **Xcode 16.2** toolchain rejected with `unexpected ',' separator`, aborting package resolution before any source built.

The original version of this PR capped `firebase-ios-sdk` at `<12.13.0`. Per review feedback, **that only defers the real fix** — Xcode 16.2 is no longer supported by Apple for App Store submission, so pinning Firebase to accommodate a dead toolchain is the wrong direction.

## Fix

Bump the build environment to **Xcode 26+** and drop the Firebase cap:

- **`Package.swift`** — reverted the upper bound back to `<13.0.0` (no Firebase pin). The `Tests` workflow already runs on **Xcode 26.2** via [mobile-ci-tools#9](https://github.com/customerio/mobile-ci-tools/pull/9) (`ios-test.yml@main` → `macos-15` + Xcode 26.2), and Swift 6.2 parses the 12.13.0 manifest without issue.
- **`.github/workflows/deploy-sdk.yml`** — bumped the CocoaPods deploy job from `macos-14` → `macos-15` and switched `setup-ios` to the `MacOS-15+iOS-26` ref (Xcode 26.2), matching `customerio-ios` so the entire build environment requires Xcode 26+.

This also clears the two Danger warnings the cap introduced (Package modified without podspec; "Could not parse Firebase version range") since `Package.swift` is now identical to `main`.

## Test plan

- [ ] `Tests` workflow on this PR is green (SPM resolves firebase-ios-sdk 12.13.x on Xcode 26.2; XCTest suite runs to completion).
- [ ] No source or version-range changes — only the toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)