### PR TITLE
test: VALIDATION ONLY — do not merge — exercise macos-26 shared workflows

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -146,7 +146,7 @@ jobs:
     if: ${{ needs.deploy-git-tag.outputs.new_release_published == 'true' || github.event_name == 'workflow_dispatch' }}
     env:
       COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Checkout git tag that got created in previous step
         uses: actions/checkout@v4
@@ -169,7 +169,7 @@ jobs:
             echo "version=${{ inputs.existing-git-tag }}" >> $GITHUB_OUTPUT
           fi
 
-      - uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@MacOS-15+iOS-26
+      - uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@macos-26
 
       - name: Install cocoapods
         run: gem install cocoapods

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -146,7 +146,7 @@ jobs:
     if: ${{ needs.deploy-git-tag.outputs.new_release_published == 'true' || github.event_name == 'workflow_dispatch' }}
     env:
       COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-    runs-on: macos-26
+    runs-on: macos-15
     steps:
       - name: Checkout git tag that got created in previous step
         uses: actions/checkout@v4
@@ -169,7 +169,7 @@ jobs:
             echo "version=${{ inputs.existing-git-tag }}" >> $GITHUB_OUTPUT
           fi
 
-      - uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@macos-26
+      - uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@MacOS-15+iOS-26
 
       - name: Install cocoapods
         run: gem install cocoapods

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,5 +4,5 @@ on: [pull_request]
 
 jobs:
   lint:
-    uses: customerio/mobile-ci-tools/.github/workflows/ios-lint.yml@main
+    uses: customerio/mobile-ci-tools/.github/workflows/ios-lint.yml@ci/macos-26
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ concurrency: # cancel previous workflow run if one exists.
 
 jobs:
   test:
-    uses: customerio/mobile-ci-tools/.github/workflows/ios-test.yml@main
+    uses: customerio/mobile-ci-tools/.github/workflows/ios-test.yml@ci/macos-26
     with:
       scheme: 'CioFirebaseWrapper'
       xcresult-name: 'CioFirebaseWrapper.xcresult'

--- a/fastlane/Scanfile
+++ b/fastlane/Scanfile
@@ -3,9 +3,15 @@
 scheme("CioFirebaseWrapper")
 
 # -destination for xcodebuild
-# chosen to be a simulator that *all* xcode versions include. Help: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#installed-simulators
+# Device *and* OS are pinned deliberately: an unpinned or nonexistent destination makes
+# fastlane log "couldn't find matching simulator" and quietly fall back to some other
+# simulator, so the OS under test becomes an accident of the runner image. A missing
+# runtime should fail loudly instead.
+# iOS 26.2 is bundled on both macos-15 and macos-26, so this destination is valid before
+# and after the runner migration. See § Installed Simulators in
+# https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md
 devices([
-  "iPhone 8"
+  "iPhone 17 (26.2)"
 ])
 
 output_types("html,junit")

--- a/fastlane/Scanfile
+++ b/fastlane/Scanfile
@@ -3,13 +3,13 @@
 scheme("CioFirebaseWrapper")
 
 # -destination for xcodebuild
-# Device *and* OS are pinned deliberately: an unpinned or nonexistent destination makes
-# fastlane log "couldn't find matching simulator" and quietly fall back to some other
-# simulator, so the OS under test becomes an accident of the runner image. A missing
-# runtime should fail loudly instead.
-# iOS 26.2 is bundled on both macos-15 and macos-26, so this destination is valid before
-# and after the runner migration. See § Installed Simulators in
-# https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md
+# Device and OS are both pinned: when a destination does not resolve, fastlane logs
+# "couldn't find matching simulator" and quietly falls back to another one, making the tested
+# OS an accident of the runner image. That is exactly how this repo ended up testing on iOS
+# 18.5 for months. iOS 26.2 ships on both macos-15 and macos-26, so this survives the runner
+# migration — but it only resolves because CI selects Xcode 26.x. An older image-default Xcode
+# cannot drive a 26.x runtime, so this depends on the xcode-version pin in mobile-ci-tools'
+# ios-test.yml. Change one, check the other.
 devices([
   "iPhone 17 (26.2)"
 ])


### PR DESCRIPTION
🚫 **Throwaway PR. Do not merge. Close once CI has reported.**

Exists only to run the shared iOS lint and test workflows from `mobile-ci-tools#13` before that PR merges. Those workflows are consumed `@main`, so nothing on a branch can exercise them — PR #10 ran its lint and test jobs against the *old* macOS 14 / 15 workflows regardless of what #13 contains.

Branched off `ci/macos-26` so it carries the Scanfile fix, with both workflow refs pointed at `@ci/macos-26`. Reproduces the state `main` will be in once MBL-2224 lands.

## Why this repo matters most

Its tests have been silently running on iOS 18.5 for months because the pinned simulator did not exist. This is the first run that exercises both a real destination **and** the new runner — and the repo has had no CI at all since 2026-06-08, so genuine test or dependency failures here are a finding rather than a migration bug.

## What to look for

- **lint** on `macos-26`, and `binny-macos-m1` executing — the arm64 swap is the highest-risk untested piece, since the old x86_64 binary relied on Rosetta being present on `macos-14` and Rosetta on `macos-26` is undocumented
- **tests** on `macos-26` with Xcode 26.6, destination resolving to `OS:26.2, name:iPhone 17`
- **no** `couldn't find matching simulator` / `falling back to default simulator`
- **no** `Downloading iOS … Simulator`

[MBL-2224: Migrate iOS CI to `macos-26` + Xcode 26.6, and stop downloading simulator runtimes we already have](https://linear.app/customerio/issue/MBL-2224/migrate-ios-ci-to-macos-26-xcode-266-and-stop-downloading-simulator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)