### PR TITLE
ci: move the deploy job to macos-26

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -146,7 +146,7 @@ jobs:
     if: ${{ needs.deploy-git-tag.outputs.new_release_published == 'true' || github.event_name == 'workflow_dispatch' }}
     env:
       COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Checkout git tag that got created in previous step
         uses: actions/checkout@v4
@@ -169,7 +169,7 @@ jobs:
             echo "version=${{ inputs.existing-git-tag }}" >> $GITHUB_OUTPUT
           fi
 
-      - uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@MacOS-15+iOS-26
+      - uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@main
 
       - name: Install cocoapods
         run: gem install cocoapods


### PR DESCRIPTION
[MBL-2224: Migrate iOS CI to `macos-26` + Xcode 26.6, and stop downloading simulator runtimes we already have](https://linear.app/customerio/issue/MBL-2224/migrate-ios-ci-to-macos-26-xcode-266-and-stop-downloading-simulator)

---

macOS 14 is fully retired on 2 Nov 2026 and macOS 15 is the next image in line, so the deploy job moves ahead of it. The shared iOS setup step also installed a simulator runtime the image already ships, which this drops.

Moves the macOS runner from 15 to 26.

## ⛔ Blocked on mobile-ci-tools#13

Split out of #10 (the Scanfile PR) so that one can merge early as a precondition without dragging this along.

Pinned at `@main` rather than a transitional branch, so it needs no follow-up repin. The trade-off is that **this PR's CI cannot pass until `mobile-ci-tools#13` merges** — until then `@main` resolves to an action defaulting to Xcode 16.2, which is not installed on `macos-26` at all. A red run here before that is expected, not a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)