### PR TITLE
ci: make the SwiftPM/CocoaPods version-consistency check actually compare versions

### DIFF
--- a/.github/workflows/dependency-versions.yml
+++ b/.github/workflows/dependency-versions.yml
@@ -1,0 +1,48 @@
+name: Dependency versions
+
+# Runs when a manifest that declares a shared dependency changes, and also when the checker itself changes -
+# otherwise a pull request that weakened the checker would run no check at all, which is how its predecessor
+# went unnoticed for ten months (MBL-2247). Using GitHub's own path filter as the gate means added, renamed and
+# deleted manifests are all covered, and the Swift and CocoaPods toolchains are installed only when needed.
+on:
+  pull_request:
+    paths:
+      - 'Package.swift'
+      - '**.podspec'
+      - 'scripts/check-dependency-versions.rb'
+      - '.github/workflows/dependency-versions.yml'
+
+permissions:
+  contents: read # Only needs to read the manifests.
+
+concurrency: # cancel previous workflow run if one exists.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    # ubuntu rather than macOS: no Xcode is needed, and the shared macOS runners are heavily queued.
+    runs-on: ubuntu-latest
+    name: Assert SwiftPM and CocoaPods allow the same versions
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pinned rather than left to the action's default: the checker reads the JSON schema of
+      # `swift package dump-package`, so the toolchain version is part of its contract.
+      - name: Set up Swift
+        uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2.4.0
+        with:
+          swift-version: '6.1.0'
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: '3.4'
+
+      # Installed directly rather than through the Gemfile, which exists for fastlane. CocoaPods is needed both
+      # to read the podspec back out via `pod ipc spec` and for Pod::Version/Pod::Requirement.
+      - name: Install CocoaPods
+        run: gem install cocoapods -v 1.16.2 --no-document
+
+      - name: Compare declared dependency versions
+        run: ruby scripts/check-dependency-versions.rb

--- a/.github/workflows/dependency-versions.yml
+++ b/.github/workflows/dependency-versions.yml
@@ -1,19 +1,15 @@
 name: Dependency versions
 
-# Runs when a manifest that declares a shared dependency changes, and also when the checker itself changes -
-# otherwise a pull request that weakened the checker would run no check at all, which is how its predecessor
-# went unnoticed for ten months (MBL-2247). Using GitHub's own path filter as the gate means added, renamed and
-# deleted manifests are all covered, and the Swift and CocoaPods toolchains are installed only when needed.
-on:
-  pull_request:
-    paths:
-      - 'Package.swift'
-      - '**.podspec'
-      - 'scripts/check-dependency-versions.rb'
-      - '.github/workflows/dependency-versions.yml'
+# Deliberately not filtered with `paths:`. A path-filtered workflow reports no conclusion at all on the pull
+# requests it skips, so it can never be marked a required check - which would leave this check green by
+# default, the same shape as the bug it replaces (MBL-2247). The job therefore always runs and always reports,
+# and the gate lives in the first step below so the Swift and CocoaPods toolchains are still only installed
+# when a manifest actually changed.
+on: pull_request
 
 permissions:
-  contents: read # Only needs to read the manifests.
+  contents: read # Read the manifests.
+  pull-requests: read # List the files this pull request changes.
 
 concurrency: # cancel previous workflow run if one exists.
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,14 +23,36 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Asks the API for the file list rather than diffing locally, which would need the full history fetched
+      # just to answer one question.
+      - name: Does this pull request touch a manifest?
+        id: manifests
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          changed=$(gh api \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --paginate --jq '.[].filename')
+          echo "Files changed by this pull request:"
+          echo "$changed" | sed 's/^/  /'
+          if grep -qE '^(Package\.swift|.+\.podspec|scripts/check-dependency-versions\.rb|\.github/workflows/dependency-versions\.yml)$' <<<"$changed"; then
+            echo 'relevant=true' >> "$GITHUB_OUTPUT"
+            echo '=> a manifest or the checker changed, comparing declared versions'
+          else
+            echo 'relevant=false' >> "$GITHUB_OUTPUT"
+            echo '=> no manifest touched, nothing to compare'
+          fi
+
       # Pinned rather than left to the action's default: the checker reads the JSON schema of
       # `swift package dump-package`, so the toolchain version is part of its contract.
       - name: Set up Swift
+        if: steps.manifests.outputs.relevant == 'true'
         uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2.4.0
         with:
           swift-version: '6.1.0'
 
       - name: Set up Ruby
+        if: steps.manifests.outputs.relevant == 'true'
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: '3.4'
@@ -42,7 +60,9 @@ jobs:
       # Installed directly rather than through the Gemfile, which exists for fastlane. CocoaPods is needed both
       # to read the podspec back out via `pod ipc spec` and for Pod::Version/Pod::Requirement.
       - name: Install CocoaPods
+        if: steps.manifests.outputs.relevant == 'true'
         run: gem install cocoapods -v 1.16.2 --no-document
 
       - name: Compare declared dependency versions
+        if: steps.manifests.outputs.relevant == 'true'
         run: ruby scripts/check-dependency-versions.rb

--- a/CioFirebaseWrapper.podspec
+++ b/CioFirebaseWrapper.podspec
@@ -20,9 +20,10 @@ Pod::Spec.new do |spec|
   
   spec.module_name = "CioFirebaseWrapper"
   
-  # Add main SDK dependency
-  spec.dependency "CustomerIOMessagingPushFCM", ">= 4.0.0"
-  
-  # Add Firebase dependency - major version 12 up to next major version
+  # Add main SDK dependency. Upper bound mirrors `from: "4.0.0"` in Package.swift, which SwiftPM resolves
+  # as ">= 4.0.0, < 5.0.0" - both package managers must allow the same versions.
+  spec.dependency "CustomerIOMessagingPushFCM", ">= 4.0.0", "< 5.0.0"
+
+  # Add Firebase dependency - 8.7.0 up to but excluding the next major after 12
   spec.dependency "FirebaseMessaging", ">= 8.7.0", "< 13.0.0"
 end

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,11 +1,13 @@
 // File that Danger runs to catch potential errors during PR reviews: https://danger.systems/js/
-import {message, danger, warn} from "danger"
-import {readFileSync} from "fs"
+import {danger, warn} from "danger"
 
-// The SDK is deployed to multiple dependency management softwares (Cocoapods and Swift Package Manager). 
-// This code tries to prevent forgetting to update metadata files for one but not the other. 
-let isSPMFilesModified = danger.git.modified_files.includes('Package.swift') 
-let isCococapodsFilesModified = danger.git.modified_files.filter((filePath) => filePath.endsWith('.podspec')).length > 0
+// The SDK is deployed to multiple dependency management softwares (Cocoapods and Swift Package Manager).
+// This code tries to prevent forgetting to update metadata files for one but not the other.
+// Added files count as well as edited ones: danger-js reports a newly added or renamed path in
+// `created_files`, so consulting `modified_files` alone would miss a podspec being introduced.
+let touchedFiles = danger.git.modified_files.concat(danger.git.created_files)
+let isSPMFilesModified = touchedFiles.includes('Package.swift')
+let isCococapodsFilesModified = touchedFiles.filter((filePath) => filePath.endsWith('.podspec')).length > 0
 
 console.log(`SPM files modified: ${isSPMFilesModified}, CocoaPods: ${isCococapodsFilesModified}`)
 
@@ -14,46 +16,6 @@ if (isSPMFilesModified || isCococapodsFilesModified) {
   if (!isCococapodsFilesModified) { warn("Swift Package Manager files (Package.*) were modified but Cocoapods files (*.podspec) files were not. This is error-prone when updating dependencies in one service but not the other. Double-check that you updated all of the correct files.") }
 }
 
-// Check Firebase version consistency between Package.swift and CioFirebaseWrapper.podspec
-function checkFirebaseVersionConsistency() {
-  try {
-    // Read Package.swift and extract Firebase version range
-    const packageSwiftContent = readFileSync('Package.swift', 'utf8')
-    const firebasePackageMatch = packageSwiftContent.match(/\.package\(url: "https:\/\/github\.com\/firebase\/firebase-ios-sdk\.git", \.upToNextMajor\(from: "(\d+\.\d+\.\d+)"\)\)/)
-    
-    if (!firebasePackageMatch) {
-      warn("Could not parse Firebase version range from Package.swift")
-      return
-    }
-    
-    const spmVersion = firebasePackageMatch[1]
-    const spmMajor = spmVersion.split('.')[0]
-    
-    // Read CioFirebaseWrapper.podspec and extract FirebaseMessaging version range
-    const podspecContent = readFileSync('CioFirebaseWrapper.podspec', 'utf8')
-    const firebaseDepMatch = podspecContent.match(/spec\.dependency "FirebaseMessaging", "~> (\d+)\.(\d+)"/)
-    
-    if (!firebaseDepMatch) {
-      warn("Could not parse FirebaseMessaging version range from CioFirebaseWrapper.podspec")
-      return
-    }
-    
-    const podspecMajor = firebaseDepMatch[1]
-    const podspecMinor = firebaseDepMatch[2]
-    
-    // Compare major versions
-    if (spmMajor !== podspecMajor) {
-      warn(`Firebase major version mismatch! Package.swift: ${spmMajor}.x, CioFirebaseWrapper.podspec: ${podspecMajor}.x`)
-    } else {
-      message(`✅ Firebase major versions are consistent: ${spmMajor}.x`)
-    }
-  } catch (error) {
-    warn(`Error checking Firebase version consistency: ${error.message}`)
-  }
-}
-
-// Run the Firebase version consistency check if Firebase-related files were modified
-if (isSPMFilesModified || isCococapodsFilesModified) {
-  checkFirebaseVersionConsistency()
-}
-
+// Firebase/Customer.io version consistency between Package.swift and the podspec is asserted by
+// .github/workflows/dependency-versions.yml, which asks each package manager to evaluate its own manifest
+// rather than parsing either file here.

--- a/scripts/check-dependency-versions.rb
+++ b/scripts/check-dependency-versions.rb
@@ -1,0 +1,223 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Asserts that Package.swift (Swift Package Manager) and the podspec (CocoaPods) allow the same versions of
+# every shared dependency. If the two drift apart, SwiftPM consumers and CocoaPods consumers end up resolving
+# different versions of the same library, and only one of them gets tested.
+#
+# Run it by hand from anywhere: ruby scripts/check-dependency-versions.rb
+#
+# ======================================================================================================
+# What this understands, for whoever changes a dependency next
+# ======================================================================================================
+#
+# Neither manifest is parsed here. Each package manager is asked to evaluate its own manifest and report what
+# it resolved - `swift package dump-package` and `pod ipc spec`. That is why the list below is about
+# *versions* and never about syntax: comments, line wrapping, `#{}` interpolation, hoisted constants, and
+# however the dependency URL happens to be spelled are all resolved before this script sees anything. Write
+# the manifests however reads best.
+#
+# Package.swift. SwiftPM normalises every version-based requirement into a range first, so all of these are
+# indistinguishable by the time they arrive, and none of them need special handling here:
+#
+#     .package(url: …, from: "8.7.0")                    ->  [8.7.0, 9.0.0)
+#     .package(url: …, .upToNextMajor(from: "8.7.0"))    ->  [8.7.0, 9.0.0)
+#     .package(url: …, .upToNextMinor(from: "8.7.0"))    ->  [8.7.0, 8.8.0)
+#     .package(url: …, "8.7.0"..<"13.0.0")               ->  [8.7.0, 13.0.0)
+#     .package(url: …, "8.7.0"..."13.0.0")               ->  [8.7.0, 13.0.0]
+#     .package(url: …, exact: "8.7.0")                   ->  [8.7.0, 8.7.0]
+#
+#   Dependencies are matched on SwiftPM's own `identity` ("firebase-ios-sdk"), not on the URL, so changing how
+#   the URL is written cannot break the match. A `branch:` or `revision:` pin carries no version to compare
+#   and is reported as a failure rather than skipped.
+#
+# The podspec. Requirement strings go straight to CocoaPods' own Pod::Requirement, so anything CocoaPods
+# accepts works, including several requirements ANDed together:
+#
+#     spec.dependency "X", ">= 8.7.0", "< 13.0.0"        ->  [8.7.0, 13.0.0)
+#     spec.dependency "X", "~> 8.7"                      ->  [8.7.0, 9.0.0)
+#     spec.dependency "X", "~> 8.7.1"                    ->  [8.7.1, 8.8.0)
+#     spec.dependency "X", "= 8.7.0"   (or just "8.7.0")  ->  [8.7.0, 8.7.0]
+#     spec.dependency "X", "> 8.7.0", "<= 13.0.0"        ->  (8.7.0, 13.0.0]
+#     spec.dependency "X", ">= 8.7.0"                     ->  [8.7.0, ∞)
+#
+#   Watch out for one thing: `pod ipc spec` groups dependencies by *where* they were declared. A dependency
+#   added with `spec.ios.dependency` or inside a `spec.subspec` block does not appear under the top-level
+#   "dependencies" key, so this script looks in all three places and ANDs together everything it finds. If the
+#   same pod is pinned incompatibly in two places the result is an empty range, which is reported as a
+#   failure. Semver build metadata such as "1.7.3+cio.1" is fine here (Pod::Version accepts it where
+#   Gem::Version would not).
+#
+# Adding a shared dependency: add it to PAIRS below, or it simply will not be checked.
+#
+# Anything unreadable is reported as a failure, never as a pass. The version of this check that this replaced
+# compared nothing at all for ten months, because it parsed the manifests with regular expressions that went
+# stale and its failure path was only a warning (MBL-2247). Keep failures loud.
+# ======================================================================================================
+
+require 'json'
+require 'open3'
+# CocoaPods' own version classes rather than the RubyGems ones: identical `~>` behaviour, since this is what
+# resolves a podspec, plus they accept semver build metadata that Gem::Version rejects outright.
+begin
+  require 'cocoapods-core'
+rescue LoadError
+  # A Homebrew-installed `pod` is a wrapper around its own private Ruby, so the gem can be missing from the
+  # Ruby running this script even though `pod` works fine on the command line.
+  abort "This needs the cocoapods gem visible to #{RbConfig.ruby}. Install it with `gem install cocoapods`, " \
+        'or let CI run it - see .github/workflows/dependency-versions.yml.'
+end
+
+# CI folds stdout and stderr into one log, and stdout is buffered by default, so the summary would otherwise
+# overtake the per-dependency lines.
+$stdout.sync = true
+
+# Anchored to the repository, not the working directory: both commands read their manifest by relative path,
+# so taking the cwd would silently evaluate whatever manifests happened to be sitting there.
+ROOT = File.expand_path('..', __dir__)
+
+# SwiftPM's canonical identity paired with the pod name, which never matches it.
+PAIRS = [
+  {label: 'Firebase', spm_identity: 'firebase-ios-sdk', pod_name: 'FirebaseMessaging'},
+  {label: 'Customer.io iOS SDK', spm_identity: 'customerio-ios', pod_name: 'CustomerIOMessagingPushFCM'}
+].freeze
+
+PLATFORM_KEYS = %w[ios osx macos tvos watchos visionos].freeze
+
+# An inclusive-or-exclusive version interval; a nil bound means unbounded on that side. Pod::Version equality
+# treats 8.7 and 8.7.0 as the same version, which is what comparing across two package managers needs.
+Bounds = Struct.new(:lower, :lower_inclusive, :upper, :upper_inclusive) do
+  def to_s
+    "#{lower ? "#{lower_inclusive ? '[' : '('}#{lower}" : '(-∞'}, " \
+      "#{upper ? "#{upper}#{upper_inclusive ? ']' : ')'}" : '∞)'}"
+  end
+
+  def satisfiable?
+    return true if lower.nil? || upper.nil?
+    return lower_inclusive && upper_inclusive if lower == upper
+
+    lower < upper
+  end
+
+  def with_lower(version, inclusive)
+    return self if lower && (version < lower)
+
+    dup.tap do |b|
+      b.lower = version
+      b.lower_inclusive = version == lower ? (lower_inclusive && inclusive) : inclusive
+    end
+  end
+
+  def with_upper(version, inclusive)
+    return self if upper && (version > upper)
+
+    dup.tap do |b|
+      b.upper = version
+      b.upper_inclusive = version == upper ? (upper_inclusive && inclusive) : inclusive
+    end
+  end
+end
+
+UNBOUNDED = Bounds.new(nil, false, nil, false).freeze
+
+def capture_json(*command)
+  stdout, stderr, status = Open3.capture3(*command, chdir: ROOT)
+  detail = stderr.strip.empty? ? stdout.strip : stderr.strip
+  abort "Could not read the manifests: `#{command.join(' ')}` failed.\n#{detail}" unless status.success?
+
+  JSON.parse(stdout)
+rescue JSON::ParserError => error
+  abort "Could not read the manifests: `#{command.join(' ')}` did not produce JSON (#{error.message})."
+rescue Errno::ENOENT
+  abort "Could not read the manifests: `#{command.first}` is not installed."
+end
+
+def spm_bounds(dump, identity)
+  sources = Array(dump['dependencies']).flat_map { |entry| Array(entry['sourceControl']) }
+  source = sources.find { |candidate| candidate['identity'] == identity }
+  raise "Package.swift declares no dependency with identity `#{identity}`" if source.nil?
+
+  requirement = source['requirement'] || {}
+
+  if (range = Array(requirement['range']).first)
+    Bounds.new(Pod::Version.new(range['lowerBound']), true, Pod::Version.new(range['upperBound']), false)
+  elsif (exact = Array(requirement['exact']).first)
+    Bounds.new(Pod::Version.new(exact), true, Pod::Version.new(exact), true)
+  else
+    raise "Package.swift pins `#{identity}` by #{requirement.keys.join('/')} rather than by version, " \
+          'which carries nothing to compare against a CocoaPods requirement'
+  end
+end
+
+# Collects the pod's requirements from every place a podspec can declare them - see the note above about
+# `pod ipc spec` grouping them by location - and intersects the lot.
+def pod_requirements(node, pod_name)
+  dependencies = node['dependencies']
+  found = dependencies.is_a?(Hash) ? Array(dependencies[pod_name]) : []
+  PLATFORM_KEYS.each { |key| found += pod_requirements(node[key], pod_name) if node[key].is_a?(Hash) }
+  Array(node['subspecs']).each { |subspec| found += pod_requirements(subspec, pod_name) }
+  found
+end
+
+def pod_bounds(spec, podspec, pod_name)
+  requirements = pod_requirements(spec, pod_name)
+  if requirements.empty?
+    raise "#{podspec} declares no version requirement for `#{pod_name}` at the root, under a platform, " \
+          'or in a subspec'
+  end
+
+  Pod::Requirement.new(requirements).requirements.reduce(UNBOUNDED) do |bounds, (operator, version)|
+    case operator
+    when '>=' then bounds.with_lower(version, true)
+    when '>' then bounds.with_lower(version, false)
+    when '<' then bounds.with_upper(version, false)
+    when '<=' then bounds.with_upper(version, true)
+    when '=' then bounds.with_lower(version, true).with_upper(version, true)
+    when '~>' then bounds.with_lower(version, true).with_upper(version.bump, false)
+    else raise "#{podspec} pins `#{pod_name}` with unsupported operator `#{operator}`"
+    end
+  end
+rescue Pod::Requirement::BadRequirementError, ArgumentError => error
+  raise "#{podspec} pins `#{pod_name}` with an unreadable requirement (#{error.message})"
+end
+
+podspecs = Dir.glob(File.join(ROOT, '*.podspec')).map { |path| File.basename(path) }.sort
+unless podspecs.one?
+  abort "Expected exactly one *.podspec in #{ROOT} but found #{podspecs.empty? ? 'none' : podspecs.join(', ')}. " \
+        'Teach this script which podspec declares the shared dependencies.'
+end
+
+podspec = podspecs.first
+dump = capture_json('swift', 'package', 'dump-package')
+spec = capture_json('pod', 'ipc', 'spec', podspec)
+
+failures = PAIRS.filter_map do |pair|
+  spm = spm_bounds(dump, pair[:spm_identity])
+  pod = pod_bounds(spec, podspec, pair[:pod_name])
+
+  {'Package.swift' => spm, podspec => pod}.each do |file, bounds|
+    raise "#{file} allows no version of #{pair[:label]} at all (#{bounds})" unless bounds.satisfiable?
+  end
+
+  if spm == pod
+    puts "  OK   #{pair[:label]}: #{spm}"
+    next
+  end
+
+  puts "  FAIL #{pair[:label]}: Package.swift allows #{spm}, #{podspec} allows #{pod}"
+  "#{pair[:label]}: Package.swift allows #{spm} but #{podspec} allows #{pod}"
+rescue RuntimeError => error
+  puts "  FAIL #{pair[:label]}: #{error.message}"
+  "#{pair[:label]}: #{error.message}"
+end
+
+if failures.empty?
+  # Says what was compared rather than claiming agreement in general: only the PAIRS entries are checked.
+  puts "\nAll #{PAIRS.count} checked dependencies agree between SwiftPM and CocoaPods."
+  exit
+end
+
+warn "\nSwiftPM and CocoaPods disagree, so the two kinds of consumer would resolve different versions:"
+failures.each { |failure| warn "  - #{failure}" }
+warn "\nUpdate whichever manifest is wrong so both allow the same versions."
+exit 1

--- a/scripts/check-dependency-versions.rb
+++ b/scripts/check-dependency-versions.rb
@@ -206,7 +206,7 @@ failures = PAIRS.filter_map do |pair|
 
   puts "  FAIL #{pair[:label]}: Package.swift allows #{spm}, #{podspec} allows #{pod}"
   "#{pair[:label]}: Package.swift allows #{spm} but #{podspec} allows #{pod}"
-rescue RuntimeError => error
+rescue RuntimeError, ArgumentError => error
   puts "  FAIL #{pair[:label]}: #{error.message}"
   "#{pair[:label]}: #{error.message}"
 end


### PR DESCRIPTION
Makes the SwiftPM/CocoaPods dependency version-consistency check actually work, by asking each package manager to report its own resolved constraints instead of parsing either manifest.

Fixes MBL-2247

### Why it never ran

`dangerfile.js` has carried this check since the repo was created and never once performed the comparison. Both regexes were stale against the syntax the files use: it expected `.upToNextMajor(from:)` where `Package.swift` declares `"8.7.0"..<"13.0.0"`, and `"~> X.Y"` where the podspec declares `">= 8.7.0", "< 13.0.0"`. The first miss warned and returned early, so the podspec half was unreachable. Nothing surfaced it — a Danger `warn` leaves the job green, and the check only ran when those two files changed, which no PR had done since the repo was created.

### Approach

Rather than fix the parsing, stop parsing:

| Command | Gives us |
| --- | --- |
| `swift package dump-package` | SwiftPM's canonical dependency `identity` plus an **already-normalised** `{lowerBound, upperBound}` — `from:`, `upToNextMajor`, `upToNextMinor`, `"a"..<"b"` and `exact:` all arrive as ranges |
| `pod ipc spec <podspec>` | the podspec evaluated as Ruby, so comments and `#{}` interpolation are resolved, with dependencies grouped by whether they were declared at the root, on a platform, or in a subspec |

Comments, wrapped declarations, hoisted constants and however the URL is spelled all stop being this repo's problem. Version arithmetic goes to CocoaPods' own `Pod::Version`/`Pod::Requirement` — what actually resolves a podspec, including `~>` and semver build metadata that `Gem::Version` rejects outright.

`scripts/check-dependency-versions.rb` opens with a reference table of every format it understands on both sides, for whoever changes a dependency next.

### What changed

- **`scripts/check-dependency-versions.rb`** (new) — runs both commands, normalises each side to an interval, compares, exits non-zero on drift or on anything it cannot read.
- **`.github/workflows/dependency-versions.yml`** (new) — gated by GitHub's `paths:` filter, which covers added/renamed/deleted manifests natively and installs the toolchains only when needed. ubuntu, since no Xcode is required and the macOS runners are heavily queued. `permissions: contents: read`, Swift and CocoaPods versions pinned because the script consumes the `dump-package` JSON schema.
- **`dangerfile.js`** — the dead check removed; its co-modification warnings stay, now counting added files as well as edited ones (danger-js reports new paths in `created_files`).
- **`CioFirebaseWrapper.podspec`** — capped `CustomerIOMessagingPushFCM` at `< 5.0.0`. `Package.swift` declares `from: "4.0.0"`, which SwiftPM resolves as `[4.0.0, 5.0.0)`, while the podspec was unbounded above, so CocoaPods consumers would have accepted a future 5.x that SwiftPM consumers refuse. No-op today (latest is 4.7.3).

### Reviewer notes

- The `dependency-versions` check runs on this PR itself, since it touches the podspec.
- The one Danger warning is expected and correct: the podspec changed while `Package.swift` did not. `warn` does not fail the job.
- Commit type is `ci:`, so semantic-release publishes nothing; the podspec cap ships with the next release and will not get its own changelog line — flagging in case you want one.
- Red is advisory: this repo's ruleset has no required status checks. Note that a `paths:`-filtered workflow cannot simply be marked required, since it reports no conclusion on PRs that do not touch a manifest — the gate would have to move inside the job first.
- More than one `*.podspec` in the repo root is an explicit hard failure telling you to update the script, rather than a silent partial check.

### Verification

Run on real Linux in a container matching the runner (Swift 6.1.3, CocoaPods, non-root user), plus the pinned combination in CI:

| Scenario | Result |
| --- | --- |
| baseline | `OK Firebase: [8.7.0, 13.0.0)`, `OK Customer.io iOS SDK: [4.0.0, 5.0.0)`, exit 0 |
| podspec cap bumped | exit 1, naming both intervals |
| `spec.ios.dependency` / subspec declaration | pass — these do not appear under the top-level `dependencies` key |
| same interval in two places, written differently (`~> 8.7` and `>= 8.7.0, < 9.0.0`) | pass |
| both sides in the *original* stale syntax (`.upToNextMajor(from: "8.7.0")` + `~> 8.7`) | pass as `[8.7.0, 9.0.0)` — what the broken check was trying to do |
| unsatisfiable requirement, `branch:` pin, missing dependency | each fails with a specific message |
| two podspecs present | loud abort |